### PR TITLE
Cast int when set redelivery delay

### DIFF
--- a/DbalContext.php
+++ b/DbalContext.php
@@ -117,7 +117,7 @@ class DbalContext implements Context
         }
 
         if (isset($this->config['redelivery_delay'])) {
-            $consumer->setRedeliveryDelay($this->config['redelivery_delay']);
+            $consumer->setRedeliveryDelay((int) $this->config['redelivery_delay']);
         }
 
         return $consumer;


### PR DESCRIPTION
If we config 'redelivery_delay' in dsn, then it will be a string, so we need to cast int