### PR TITLE
Fixing incorrect parameter name

### DIFF
--- a/DbalConsumerHelperTrait.php
+++ b/DbalConsumerHelperTrait.php
@@ -102,7 +102,7 @@ trait DbalConsumerHelperTrait
             ->set('redelivered', ':redelivered')
             ->andWhere('redeliver_after < :now')
             ->andWhere('delivery_id IS NOT NULL')
-            ->setParameter(':now', time(), DbalType::BIGINT)
+            ->setParameter('now', time(), DbalType::BIGINT)
             ->setParameter('deliveryId', null, DbalType::GUID)
             ->setParameter('redelivered', true, DbalType::BOOLEAN)
         ;
@@ -130,7 +130,7 @@ trait DbalConsumerHelperTrait
             ->andWhere('delivery_id IS NULL')
             ->andWhere('redelivered = :redelivered')
 
-            ->setParameter(':now', time(), DbalType::BIGINT)
+            ->setParameter('now', time(), DbalType::BIGINT)
             ->setParameter('redelivered', false, DbalType::BOOLEAN)
         ;
 


### PR DESCRIPTION
Fixing incorrect parameter name, that fails with newest version of DBAL.

"Doctrine\DBAL\ArrayParameters\Exception\MissingNamedParameter: Named parameter "now" does not have a bound value."